### PR TITLE
Reduces min-height of #third-section

### DIFF
--- a/assets/scss/style.css
+++ b/assets/scss/style.css
@@ -252,7 +252,6 @@ ul li a{
 
 
 #third-section{
-    min-height: 100vh;
     width: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Introduction
Hello - I am a fellow Strava user (found this on reddit) and FE dev and went peeking around Github to find your webapp! I would love to contribute to the UI a bit if you'll have me!

## Reduces min-height of #third-section

With `min-height: 100vh`, there were instances where `#third-section`
was a tad larger than was necessary. By removing the `min-height`,
the container maintains the appropriate height to display all of the
child content and eliminates the excess in space

**`min-height: 100vh`**
![Screen Shot 2020-11-08 at 8 33 58 PM](https://user-images.githubusercontent.com/11970008/98491263-481bea00-2202-11eb-9d17-5a07fa553498.png)

**removes `min-height: 100vh`**
![Screen Shot 2020-11-08 at 8 34 14 PM](https://user-images.githubusercontent.com/11970008/98491282-579b3300-2202-11eb-9b45-a3fd663a3269.png)